### PR TITLE
Bump version of tools-nibble 1.0-alpha.7

### DIFF
--- a/lib/constants.js
+++ b/lib/constants.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var github_server = 'https://github.com/AdaptiveMe/adaptive-tools-nibble/releases/download/';
-var nibble_version = '1.0-alpha.6';
+var nibble_version = '1.0-alpha.7';
 
 var platforms = [
   {


### PR DESCRIPTION
https://github.com/AdaptiveMe/adaptive-tools-nibble/releases/tag/1.0-alp
ha.7
